### PR TITLE
Add Kathryn's resume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ all: austen-sharpe.pdf \
 	christina-gosnell.pdf \
 	dazhong-xia.pdf \
 	ella-belfer.pdf \
+	kathryn-mazaitis.pdf \
 	katie-lamb.pdf \
 	zach-schira.pdf \
 	zane-selvans.pdf

--- a/src/ella-belfer.md
+++ b/src/ella-belfer.md
@@ -69,7 +69,7 @@ Graduate Student Instructor
 Research Assistant
 : May 2016 - Aug 2018
 
-- Wrote and conducted background research for IPCC Special Report on 1.5°C and UNEP Adaptation Gap report, with a focus on vulnerability assessments to inform climate change adaptation planning.
+- Wrote and conducted background research for IPCC Special Report on 1.5\textdegree C and UNEP Adaptation Gap report, with a focus on vulnerability assessments to inform climate change adaptation planning.
 - Developed methodology to conduct topic modeling analysis of state adaptation policies, writing and publishing manuscript for non-technical audience.
 - Provided ongoing editorial support for journal articles, grant proposals, and public communications for the CCARG lab.
 
@@ -79,7 +79,7 @@ Research Assistant
 - Rempel, J., Belfer, E., Ray, I. & Morello-Frosch, R. Access for sale? Overlying rights, land transactions, and groundwater in California (2024). Environmental Research Letters, 19 024017.
   - Presented at the 2021 AAG conference.
 - Lesnikowski, A., Belfer, E., Rodman, E., Biesbroek, R., Smith, J., Wilkerson, J.D., Ford, J.D., Berrang Ford, L. (2019). Frontiers in data analytics for adaptation research: Topic modeling, WIRES Climate Change, e576 1-15.
-- Contributing author. IPCC Special Report on Global Warming of 1.5°C (2018), Chapter 4: Strengthening and implementing the global response to the threat of climate change.
+- Contributing author. IPCC Special Report on Global Warming of 1.5\textdegree C (2018), Chapter 4: Strengthening and implementing the global response to the threat of climate change.
 - Belfer, E., Ford, J.D., Maillet, M., Araos, M., Flynn, M. Pursuing an Indigenous Platform: Exploring Opportunities and Constraints for Indigenous Participation in the UNFCCC, Global Environmental Politics, 19(1), 12-33.
 - Belfer, E., Ford, J.D., Maillet, M. (2017). Representation of Indigenous peoples in climate change reporting, Climatic Change, 145(1-2), 57-70.
   - Selected to be one of Nature Climate Change’s Research Highlights, and presented at the 2017 ArcticNet conference.

--- a/src/kathryn-mazaitis.md
+++ b/src/kathryn-mazaitis.md
@@ -8,8 +8,6 @@ right-column:
   - "GitHub: [github.com/krivard](https://github.com/krivard)"
 ...
 
-# Summary
-
 # Experience
 
 ## Catalyst Cooperative
@@ -21,7 +19,6 @@ Data Wrangler
 - Developing an introductory course in open data science and collaborative software engineering for early-career graduate students who may not have a computer science background.
 - Developing internal tooling for project planning and resource allocation.
 - Writing project proposals, grant reports, blog posts, and technical documentation.
-- Using Python, R, GitHub Actions, Jinja, dbt, Docker, AWS, and GCP.
 
 ## Carnegie Mellon University
 
@@ -36,8 +33,6 @@ Principal Research Programmer
 - Scaled a database beyond the capacity of signed 32-bit integer IDs and navigated the bumpy transition to uint64.
 - Wrote project proposals, quarterly OKRs, blog posts, and papers.
 - Wrote and delivered technical talks to expert and novice audiences.
-- Used Python, R, HTML/Svelte, GitHub Actions, PHP, possibly-excessive creative applications of GNU Make, MariaDB, MySQL, Flask, Docker, Hugo, and AWS.
-
 
 Senior Research Programmer
 : 2018 - 2020
@@ -47,7 +42,6 @@ Senior Research Programmer
 - Advised students on programming, troubleshooting, and project management for research projects.
 - Maintained servers and network storage for students.
 - Wrote papers and project documentation.
-- Used Python, Java/Android, Django, and Prolog.
 
 Senior Research Programmer
 : 2009 - 2018
@@ -59,20 +53,22 @@ Senior Research Programmer
 - Advised students on programming, troubleshooting, and project management for research projects.
 - Maintained servers and network storage for students.
 - Wrote papers and project documentation.
-- Used Java, Python, R, creative applications of GNU Make, Prolog, Tomcat/Struts, Solr, HTML/CSS, and AWS.
 
 Research Programmer / Analyst
 : 2007 - 2009
 
 - Anthony Tomasic, Institute for Software Research
 - Developed prototype user interfaces and fullstack production software for novel digital assistants.
-- Assisted with live user studies.
+- Developed and ran wizard-of-oz utilities during live user studies.
 - Wrote papers and project documentation.
-- Used JavaScript, Java/Tomcat, and obscure corners of the Mozilla Firefox plug-in architecture; also Adobe Air, HyperCard, and paper prototyping.
 
-# Projects
+# Selected Publications
 
-# Publications
+- Joshi, Ananya, **Kathryn Mazaitis**, Roni Rosenfeld, and Bryan Wilder. “Computationally Assisted Quality Control for Public Health Data Streams.” In Proceedings of the International Joint Conference on Artificial Intelligence, Vol. 32, 2023. https://arxiv.org/abs/2306.16914
+- Arabshahi, Forough, Jennifer Lee, Mikayla Gawarecki, **Kathryn Mazaitis**, Amos Azaria, and Tom Mitchell. “Conversational Neuro-Symbolic Commonsense Reasoning.” In Proceedings of the AAAI Conference on Artificial Intelligence, 35:4902–11, 2021. https://arxiv.org/abs/2006.10022
+- Cohen, William, Fan Yang, and **Kathryn Mazaitis**. “Tensorlog: A Probabilistic Database Implemented Using Deep-Learning Infrastructure.” Journal of Artificial Intelligence Research 67 (2020): 285–325.
+- **Mazaitis, Kathryn**, and Haakon Faste. “How Learning Works in Design Education: Educating for Creative Awareness Through Formative Reflexivity.” In Proceedings of the Designing Interactive Systems Conference, 298–307, 2012 (Honorable mention)
+- Gardiner, Steven, Anthony Tomasic, John Zimmerman, Rafae Aziz, and **Kathryn Mazaitis**. “Mixer: Mixed-Initiative Data Retrieval and Integration by Example.” In Proceedings of the 13th IFIP TC 13 International Conference on Human-Computer Interaction - Volume Part I, 426–43. Interact’11. Lisbon, Portugal: Springer-Verlag, 2011 (Brian Shackel Award / Best Paper)
 
 # Education
 
@@ -86,3 +82,5 @@ Franklin W. Olin College of Engineering, Needham MA
 : Engineering with Concentration in Computing, B.Sc.; 2006.
 
 # Skills
+
+Python, R, GitHub, Jinja, dbt, Docker, AWS, GCP, HTML/CSS, PHP, GNU Make, MariaDB, MySQL, Flask, Hugo, Java, Django, Prolog, JavaScript, Solr, Linux, MacOS, bash, LaTeX, typst

--- a/src/kathryn-mazaitis.md
+++ b/src/kathryn-mazaitis.md
@@ -1,0 +1,88 @@
+---
+name: Kathryn Mazaitis
+
+left-column:
+  - "Email: [kathryn.mazaitis@catalyst.coop](mailto:kathryn.mazaitis@catalyst.coop)"
+
+right-column:
+  - "GitHub: [github.com/krivard](https://github.com/krivard)"
+...
+
+# Summary
+
+# Experience
+
+## Catalyst Cooperative
+
+Data Wrangler
+: 2025 - present
+
+- Developing and maintaining open source data pipelines for hundreds of tables making federal and state reporting in the United States' energy system available to researchers, policy advocates, and the private sector.
+- Developing an introductory course in open data science and collaborative software engineering for early-career graduate students who may not have a computer science background.
+- Developing internal tooling for project planning and resource allocation.
+- Writing project proposals, grant reports, blog posts, and technical documentation.
+- Using Python, R, GitHub Actions, Jinja, dbt, Docker, AWS, and GCP.
+
+## Carnegie Mellon University
+
+Principal Research Programmer
+: 2020 - 2023
+
+- Delphi Group, Machine Learning Department
+- Ran the Engineering team for an epidemiological modeling research group during the COVID-19 pandemic state of emergency.
+- Grew the team from 4-6 to 14-16 over three years, starting as a one-woman recruiting/interviewing/hiring show and leaving behind a hiring committee with shared values and a sustainable interview process.
+- Developed and maintained data pipelines for hundreds of real-time, daily, geographically detailed time series used by thousands of researchers to continuously predict the course of the pandemic and advise the CDC.
+- Worked with Google.org Fellows to develop technologies and procedures to adapt to extreme growth in team, data, and user base.
+- Scaled a database beyond the capacity of signed 32-bit integer IDs and navigated the bumpy transition to uint64.
+- Wrote project proposals, quarterly OKRs, blog posts, and papers.
+- Wrote and delivered technical talks to expert and novice audiences.
+- Used Python, R, HTML/Svelte, GitHub Actions, PHP, possibly-excessive creative applications of GNU Make, MariaDB, MySQL, Flask, Docker, Hugo, and AWS.
+
+
+Senior Research Programmer
+: 2018 - 2020
+
+- Tom Mitchell, Machine Learning Department
+- Developed software for digital assistants and knowledge base reasoning research prototypes.
+- Advised students on programming, troubleshooting, and project management for research projects.
+- Maintained servers and network storage for students.
+- Wrote papers and project documentation.
+- Used Python, Java/Android, Django, and Prolog.
+
+Senior Research Programmer
+: 2009 - 2018
+
+- William Cohen, Machine Learning Department
+- Developed web frontends for search engine research prototypes.
+- Developed data processing and analysis tools for machine learning experiments in knowledge base completion and question answering tasks.
+- Scaled up machine learning research prototypes to handle more data, faster, and permit swapping out model components for experimental development.
+- Advised students on programming, troubleshooting, and project management for research projects.
+- Maintained servers and network storage for students.
+- Wrote papers and project documentation.
+- Used Java, Python, R, creative applications of GNU Make, Prolog, Tomcat/Struts, Solr, HTML/CSS, and AWS.
+
+Research Programmer / Analyst
+: 2007 - 2009
+
+- Anthony Tomasic, Institute for Software Research
+- Developed prototype user interfaces and fullstack production software for novel digital assistants.
+- Assisted with live user studies.
+- Wrote papers and project documentation.
+- Used JavaScript, Java/Tomcat, and obscure corners of the Mozilla Firefox plug-in architecture; also Adobe Air, HyperCard, and paper prototyping.
+
+# Projects
+
+# Publications
+
+# Education
+
+Carnegie Mellon University, Pittsburgh PA
+: Human-Computer Interaction, masters coursework; 2015.
+
+Carnegie Mellon University, Pittsburgh PA
+: Robotics, doctoral coursework; 2007.
+
+Franklin W. Olin College of Engineering, Needham MA
+: Engineering with Concentration in Computing, B.Sc.; 2006.
+
+# Skills

--- a/templates/jb2resume.latex
+++ b/templates/jb2resume.latex
@@ -17,6 +17,7 @@
 \usepackage[svgnames]{xcolor}
 \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}
 \usepackage[utf8]{inputenc}
+\usepackage{textcomp}
 
 % Your name on the resume
 \def\name{$name$}


### PR DESCRIPTION
# Overview

What problem does this address?

What did you change in this PR?

- Add .md file for Kathryn
- List Kathryn file in default make target
- Minor fix to packages/commands so Ella's resume builds

# Testing

How did you make sure this worked? How can a reviewer verify this?

Ran `make`, viewed results

# To-do list

- [x] complete or remove remaining sections from the template
- [x] Review the PR yourself and call out any questions or issues you have

